### PR TITLE
Fixed a Jacobian test for PETSc-3.9.4

### DIFF
--- a/tests/jacobian/jn21.i
+++ b/tests/jacobian/jn21.i
@@ -122,6 +122,7 @@
 [Executioner]
   type = Transient
   solve_type = Newton
+  num_steps = 1
   dt = 1E-5
 []
 


### PR DESCRIPTION
`PETSc-3.9.4` has a little different way to compute FD Jacobian. If users are intending to test the Jacobian at the frist time step, we have to use `num_steps = 1`