### PR TITLE
Remove unused params

### DIFF
--- a/tests/bcs/s03.i
+++ b/tests/bcs/s03.i
@@ -208,6 +208,5 @@
 [Outputs]
   execute_on = 'timestep_end'
   file_base = s03
-  output_initial = false
   csv = true
 []

--- a/tests/dirac/st01.i
+++ b/tests/dirac/st01.i
@@ -202,7 +202,6 @@
 [Outputs]
   execute_on = 'timestep_end'
   file_base = st01
-  output_initial = false
   exodus = false
   csv = true
 []

--- a/tests/dirac/st04.i
+++ b/tests/dirac/st04.i
@@ -162,7 +162,6 @@
 [Outputs]
   execute_on = 'timestep_end'
   file_base = st04
-  output_initial = false
   exodus = false
   csv = true
 []

--- a/tests/dirac/st05.i
+++ b/tests/dirac/st05.i
@@ -160,7 +160,6 @@
 [Outputs]
   execute_on = 'timestep_end'
   file_base = st05
-  output_initial = false
   exodus = false
   csv = true
 []

--- a/tests/dirac/st06.i
+++ b/tests/dirac/st06.i
@@ -160,7 +160,6 @@
 [Outputs]
   execute_on = 'timestep_end'
   file_base = st06
-  output_initial = false
   exodus = false
   csv = true
 []

--- a/tests/dirac/st07.i
+++ b/tests/dirac/st07.i
@@ -213,7 +213,6 @@
 [Outputs]
   execute_on = 'timestep_end'
   file_base = st07
-  output_initial = false
   exodus = false
   csv = true
 []

--- a/tests/materials/zones03.i
+++ b/tests/materials/zones03.i
@@ -228,7 +228,6 @@
 
 [Outputs]
   file_base = zones03
-  output_final = true
   [./exodus]
     type = Exodus
     hide = por_zone

--- a/tests/materials/zones06.i
+++ b/tests/materials/zones06.i
@@ -236,7 +236,6 @@
 
 [Outputs]
   file_base = zones06
-  output_final = true
   [./exodus]
     type = Exodus
     hide = por_zone

--- a/tests/sinks/s02.i
+++ b/tests/sinks/s02.i
@@ -221,10 +221,5 @@
   execute_on = 'timestep_end'
   hide = one
   file_base = s02
-  output_initial = false
   csv = true
-[]
-
-[Problem]
-  use_legacy_uo_initialization = true
 []

--- a/tests/sinks/s05.i
+++ b/tests/sinks/s05.i
@@ -216,10 +216,5 @@
 [Outputs]
   execute_on = 'timestep_end'
   file_base = s05
-  output_initial = false
   csv = true
-[]
-
-[Problem]
-  use_legacy_uo_initialization = true
 []


### PR DESCRIPTION
MOOSE is changing the default behavior of unused parameters from a warning to an error. Since there are tests in this Moose app with unused parameters, this app's tests must have there unused parameters removed.

I am particularly concerned about some of these parameters making the tests not work as intended once removed, so please review just to make sure.
Closes #60 